### PR TITLE
Prevent duplicate subscribers on a channel

### DIFF
--- a/src/tinymq_channel_controller.erl
+++ b/src/tinymq_channel_controller.erl
@@ -26,7 +26,7 @@ handle_call(_From, _, State) ->
     {noreply, State}.
 
 handle_cast({From, subscribe, 'now', Subscriber}, State) ->
-    NewSubscribers = [{erlang:monitor(process, Subscriber), Subscriber}|State#state.subscribers],
+    NewSubscribers = add_or_do_nothing(Subscriber, State#state.subscribers),
     gen_server:reply(From, {ok, now_to_micro_seconds(erlang:now())}),
     {noreply, purge_old_messages(State#state{ subscribers = NewSubscribers })};
 
@@ -114,5 +114,12 @@ pull_messages(Timestamp, Subscriber, State) ->
             Subscriber ! {self(), Now, ReturnMessages},
             {State#state.subscribers, Now};
         _ ->
-            {[{erlang:monitor(process, Subscriber), Subscriber}|State#state.subscribers], Now}
+            {add_or_do_nothing(Subscriber, State#state.subscribers), Now}
     end.
+
+% Checks if the new subscriber pid already has a monitor
+add_or_do_nothing(NewSubscriber, Subscribers) ->
+        case lists:any(fun({_Ref, Pid}) -> Pid == NewSubscriber end, Subscribers) of
+		true -> Subscribers;
+		false -> [{erlang:monitor(process, NewSubscriber), NewSubscriber} | Subscribers]
+	end.


### PR DESCRIPTION
Checks if the new subscriber pid is already subscribed and do not add it to the list of subscribers more than once.

On second thought, the function name could be called:
add_subscriber_if_not_subscribed(NewSubscriber, Subscribers)
